### PR TITLE
Change errorCodes from symbols to strings

### DIFF
--- a/src/base/errors/exchange.error.js
+++ b/src/base/errors/exchange.error.js
@@ -2,10 +2,10 @@ const ZenfuseBaseError = require('./base.error');
 
 class ExchangeBaseException extends ZenfuseBaseError {
     static errorCodes = {
-        INVALID_CREDENTIALS: Symbol('INVALID_CREDENTIALS'),
-        INSUFFICIENT_FUNDS: Symbol('INSUFFICIENT_FUNDS'),
-        INVALID_ORDER: Symbol('INVALID_ORDER'),
-        UNKNOWN_EXCEPTION: Symbol('UNKNOWN_EXCEPTION'),
+        INVALID_CREDENTIALS: 'INVALID_CREDENTIALS',
+        INSUFFICIENT_FUNDS: 'INSUFFICIENT_FUNDS',
+        INVALID_ORDER: 'INVALID_ORDER',
+        UNKNOWN_EXCEPTION: 'UNKNOWN_EXCEPTION',
     };
 }
 

--- a/src/exchanges/binance/errors/api.error.js
+++ b/src/exchanges/binance/errors/api.error.js
@@ -1,17 +1,15 @@
 const ExchangeBaseException = require('../../../base/errors/exchange.error');
 const utils = require('../../../base/utils/utils');
 
-const codes = ExchangeBaseException.errorCodes;
-
 /**
  * @see https://binance-docs.github.io/apidocs/spot/en/#error-codes
  */
 class BinanceApiException extends ExchangeBaseException {
     static codesMap = new Map([
-        [-1022, codes.INVALID_CREDENTIALS],
-        [-2014, codes.INVALID_CREDENTIALS],
-        [-2015, codes.INVALID_CREDENTIALS],
-        [-2010, codes.INSUFFICIENT_FUNDS],
+        [-1022, 'INVALID_CREDENTIALS'],
+        [-2014, 'INVALID_CREDENTIALS'],
+        [-2015, 'INVALID_CREDENTIALS'],
+        [-2010, 'INSUFFICIENT_FUNDS'],
     ]);
 
     /**
@@ -27,7 +25,7 @@ class BinanceApiException extends ExchangeBaseException {
                 err.response.body.code,
             );
         } else {
-            this.code = codes.UNKNOWN_EXCEPTION;
+            this.code = 'UNKNOWN_EXCEPTION';
         }
 
         this.response = err.response.body;

--- a/src/exchanges/bithumb/errors/api.error.js
+++ b/src/exchanges/bithumb/errors/api.error.js
@@ -2,15 +2,13 @@ const { HTTPError } = require('got');
 const ExchangeBaseException = require('../../../base/errors/exchange.error');
 const utils = require('../../../base/utils/utils');
 
-const codes = ExchangeBaseException.errorCodes;
-
 class BitglobalApiError extends ExchangeBaseException {
     static codesMap = new Map([
-        ['9000', codes.INVALID_CREDENTIALS],
-        ['9002', codes.INVALID_CREDENTIALS],
-        ['9005', codes.INVALID_CREDENTIALS],
-        ['9005', codes.INVALID_CREDENTIALS],
-        ['20003', codes.INSUFFICIENT_FUNDS],
+        ['9000', 'INVALID_CREDENTIALS'],
+        ['9002', 'INVALID_CREDENTIALS'],
+        ['9005', 'INVALID_CREDENTIALS'],
+        ['9005', 'INVALID_CREDENTIALS'],
+        ['20003', 'INSUFFICIENT_FUNDS'],
     ]);
 
     /**
@@ -39,7 +37,7 @@ class BitglobalApiError extends ExchangeBaseException {
         if (BitglobalApiError.codesMap.has(bErrCode)) {
             this.code = BitglobalApiError.codesMap.get(bErrCode);
         } else {
-            this.code = codes.UNKNOWN_EXCEPTION;
+            this.code = 'UNKNOWN_EXCEPTION';
         }
     }
 }

--- a/src/exchanges/ftx/errors/api.error.js
+++ b/src/exchanges/ftx/errors/api.error.js
@@ -1,13 +1,11 @@
 const ExchangeBaseException = require('../../../base/errors/exchange.error');
 const utils = require('../../../base/utils/utils');
 
-const codes = ExchangeBaseException.errorCodes;
-
 class FtxApiException extends ExchangeBaseException {
     static codesMap = new Map([
-        ['Not logged in: Invalid API key', codes.INVALID_CREDENTIALS],
-        ['Invalid signature', codes.INVALID_CREDENTIALS],
-        ['Not enough balances', codes.INSUFFICIENT_FUNDS],
+        ['Not logged in: Invalid API key', 'INVALID_CREDENTIALS'],
+        ['Invalid signature', 'INVALID_CREDENTIALS'],
+        ['Not enough balances', 'INSUFFICIENT_FUNDS'],
     ]);
 
     /**
@@ -20,7 +18,7 @@ class FtxApiException extends ExchangeBaseException {
         if (FtxApiException.codesMap.has(errMsg)) {
             this.code = FtxApiException.codesMap.get(errMsg);
         } else {
-            this.code = codes.UNKNOWN_EXCEPTION;
+            this.code = 'UNKNOWN_EXCEPTION';
         }
 
         this.response = err.response.body;

--- a/src/exchanges/okx/errors/api.error.js
+++ b/src/exchanges/okx/errors/api.error.js
@@ -1,17 +1,15 @@
 const ExchangeBaseException = require('../../../base/errors/exchange.error');
 const utils = require('../../../base/utils/utils');
 
-const codes = ExchangeBaseException.errorCodes;
-
 /**
  * @see https://www.okx.com/docs-v5/en/#error-code
  */
 class OkxApiException extends ExchangeBaseException {
     static codesMap = new Map([
-        ['50111', codes.INVALID_CREDENTIALS],
-        ['50113', codes.INVALID_CREDENTIALS],
-        ['58350', codes.INSUFFICIENT_FUNDS],
-        ['51008', codes.INSUFFICIENT_FUNDS],
+        ['50111', 'INVALID_CREDENTIALS'],
+        ['50113', 'INVALID_CREDENTIALS'],
+        ['58350', 'INSUFFICIENT_FUNDS'],
+        ['51008', 'INSUFFICIENT_FUNDS'],
     ]);
 
     /**
@@ -36,7 +34,7 @@ class OkxApiException extends ExchangeBaseException {
         if (OkxApiException.codesMap.has(oErrCode)) {
             this.code = OkxApiException.codesMap.get(oErrCode);
         } else {
-            this.code = codes.UNKNOWN_EXCEPTION;
+            this.code = 'UNKNOWN_EXCEPTION';
         }
 
         this.response = body;

--- a/types/base/errors/exchange.error.d.ts
+++ b/types/base/errors/exchange.error.d.ts
@@ -1,10 +1,10 @@
 export = ExchangeBaseException;
 declare class ExchangeBaseException extends ZenfuseBaseError {
     static errorCodes: {
-        INVALID_CREDENTIALS: symbol;
-        INSUFFICIENT_FUNDS: symbol;
-        INVALID_ORDER: symbol;
-        UNKNOWN_EXCEPTION: symbol;
+        INVALID_CREDENTIALS: string;
+        INSUFFICIENT_FUNDS: string;
+        INVALID_ORDER: string;
+        UNKNOWN_EXCEPTION: string;
     };
 }
 import ZenfuseBaseError = require("./base.error");

--- a/types/exchanges/binance/errors/api.error.d.ts
+++ b/types/exchanges/binance/errors/api.error.d.ts
@@ -3,12 +3,12 @@ export = BinanceApiException;
  * @see https://binance-docs.github.io/apidocs/spot/en/#error-codes
  */
 declare class BinanceApiException extends ExchangeBaseException {
-    static codesMap: Map<number, symbol>;
+    static codesMap: Map<number, string>;
     /**
      * @param {import('got').HTTPError} err
      */
     constructor(err: import('got').HTTPError);
-    code: symbol;
+    code: string;
     response: unknown;
     httpError: import("got").HTTPError;
 }

--- a/types/exchanges/bithumb/errors/api.error.d.ts
+++ b/types/exchanges/bithumb/errors/api.error.d.ts
@@ -1,13 +1,13 @@
 export = BitglobalApiError;
 declare class BitglobalApiError extends ExchangeBaseException {
-    static codesMap: Map<string, symbol>;
+    static codesMap: Map<string, string>;
     /**
      * @param {import('got').HTTPError | *} err
      */
     constructor(err: import('got').HTTPError | any);
     response: any;
     httpError: HTTPError;
-    code: symbol;
+    code: string;
 }
 import ExchangeBaseException = require("../../../base/errors/exchange.error");
 import { HTTPError } from "got/dist/source/core";

--- a/types/exchanges/ftx/errors/api.error.d.ts
+++ b/types/exchanges/ftx/errors/api.error.d.ts
@@ -1,11 +1,11 @@
 export = FtxApiException;
 declare class FtxApiException extends ExchangeBaseException {
-    static codesMap: Map<string, symbol>;
+    static codesMap: Map<string, string>;
     /**
      * @param {import('got').HTTPError} err
      */
     constructor(err: import('got').HTTPError);
-    code: symbol;
+    code: string;
     response: unknown;
     httpError: import("got").HTTPError;
 }

--- a/types/exchanges/okx/errors/api.error.d.ts
+++ b/types/exchanges/okx/errors/api.error.d.ts
@@ -3,13 +3,13 @@ export = OkxApiException;
  * @see https://www.okx.com/docs-v5/en/#error-code
  */
 declare class OkxApiException extends ExchangeBaseException {
-    static codesMap: Map<string, symbol>;
+    static codesMap: Map<string, string>;
     /**
      * @param {import('got').HTTPError | null} err
      * @param {*} body
      */
     constructor(err: import('got').HTTPError | null, body: any);
-    code: symbol;
+    code: string;
     response: any;
     httpError: import("got").HTTPError;
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,13 +32,10 @@ import FTX = require("./exchanges/ftx");
 import Bitglobal = require("./exchanges/bithumb");
 import OKX = require("./exchanges/okx");
 export declare const errorCodes: {
-    INVALID_CREDENTIALS: symbol;
-    INSUFFICIENT_FUNDS: symbol;
-    /**
-     * @enum
-     */
-    INVALID_ORDER: symbol;
-    UNKNOWN_EXCEPTION: symbol;
+    INVALID_CREDENTIALS: string;
+    INSUFFICIENT_FUNDS: string;
+    INVALID_ORDER: string;
+    UNKNOWN_EXCEPTION: string;
 };
 export declare const config: {
     get(key: any): any;


### PR DESCRIPTION
## Checklist

-   [x] `npm run lint` doesn't have errors
-   [x] `npm run test` passes
-   [x] `npm run test:e2e EXCHANGE_NAME` passes
-   [x] `npm run format` committed
-   [x] `npm run build:types` committed
